### PR TITLE
Extend #186: Add GitHub Action for black formatter

### DIFF
--- a/.github/workflows/black-formatting.yml
+++ b/.github/workflows/black-formatting.yml
@@ -1,0 +1,49 @@
+name: Black Formatting
+
+on: [pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: Output env variables
+        run: |
+           echo "GITHUB_WORKFLOW=${GITHUB_WORKFLOW}"
+           echo "GITHUB_ACTION=$GITHUB_ACTION"
+           echo "GITHUB_ACTIONS=$GITHUB_ACTIONS"
+           echo "GITHUB_ACTOR=$GITHUB_ACTOR"
+           echo "GITHUB_REPOSITORY=$GITHUB_REPOSITORY"
+           echo "GITHUB_EVENT_NAME=$GITHUB_EVENT_NAME"
+           echo "GITHUB_EVENT_PATH=$GITHUB_EVENT_PATH"
+           echo "GITHUB_WORKSPACE=$GITHUB_WORKSPACE"
+           echo "GITHUB_SHA=$GITHUB_SHA"
+           echo "GITHUB_REF=$GITHUB_REF"
+           echo "GITHUB_HEAD_REF=$GITHUB_HEAD_REF"
+           echo "GITHUB_BASE_REF=$GITHUB_BASE_REF"
+           echo "::debug::---Start content of file $GITHUB_EVENT_PATH"
+           cat $GITHUB_EVENT_PATH
+           echo "\n"
+           echo "::debug::---end"
+
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.7
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip black
+
+      - name: Run black
+        id: black
+        run: |
+          black . > project.diff
+          echo "::set-output name=rc::$?"
+
+      - name: Upload diff artifact
+        uses: actions/upload-artifact@v1
+        with:
+          name: black-project-diff
+          path: project.diff


### PR DESCRIPTION
The GH Action does basically this:

1. Setup Python 3.7
2. Install dependencies (mainly black)
3. Run black and create a diff file
4. Upload the diff as artifact

Currently, it does not any pip caching (I had some problems
with that; it didn't work reliably).